### PR TITLE
Link explanation of 'settings' to data tree page

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ In addition to the default entries of [npm] the `package.json` file contains a `
 
 And here is a list of available options:
 
-* `settings`: any entry provided here will be translated to an entry in `build/Info.plist`, which is the main control file defining the properties of a dizmo. Two properties, that you might also need to set, are `api-version` and `elements-version`. If you want to *downgrade* the generated skeleton, so that it is compatible with older versions of dizmoViewer, you would set them for example to `1.3` and `1.0` respectively.
+* `settings`: any entry provided here will be translated to an entry in `build/Info.plist`, which is the main control file defining the properties of a dizmo. Two properties, that you might also need to set, are `api-version` and `elements-version`. If you want to *downgrade* the generated skeleton, so that it is compatible with older versions of dizmoViewer, you would set them for example to `1.3` and `1.0` respectively. The `attributes` object allows you to set attributes of a dizmo even before the JavaScript gets executed. For a full list of all the attributes that can be set please refer to the [data tree page](https://www.dizmo.com/developer/reference/data-tree/) in our documentation.
 
 * `store`: configuration entries required by `npm run upload`, which needs `store/host` (by default pointing to `https://store-api.dizmo.com`), `store/user` and `store/pass`. The latter two should *not* be directly set in `package.json` but instead via the default configuration (see below), to avoid the store credentials getting accidentally committed to a version control system.
 


### PR DESCRIPTION
We have made the experience that many users are somewhat familiar with
using dizmoGen but one part that is confusing is how to set dizmo
attributes. Many users are also not aware of the data tree page in the documentation or find it hard to use, but that doesn't concern dizmoGen, of course.

This extends the README explaining what "attributes" within "settings"
in the package.json does. It also links to the full documentation of all
the attributes.