### PR TITLE
Add a table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,23 @@
 # @dizmo/generator-dizmo
 > Dizmo generator
 
+## Table of contents
+* [Prerequisites](#prerequisites)
+* [How does dizmoGen work?](#how-does-dizmogen-work)
+* [Installation](#installation)
+* [Quick start](#quick-start)
+* [Caching](#caching)
+* [Upgrading the Build System](#upgrading-the-build-system)
+* [Skeleton](#skeleton)
+* [Package manager: package.json](#package-manager-packagejson)
+* [NPM scripts](#npm-scripts)
+* [CLI options](#cli-options)
+* [Build](#build)
+* [Extended sub-generators](#extended-sub-generators)
+* [Miscellanea](#miscellanea)
+* [Troubleshooting/FAQ](#troubleshootingfaq)
+* [Copyright](#copyright)
+
 ## Prerequisites
 
 * [Node.js] v10.16.3 LTS (or higher); for Linux distribution based packages (`deb` or `rpm`) see also [binary distributions](https://github.com/nodesource/distributions).


### PR DESCRIPTION
I think many devs read this documentation in a way where they know what they are looking for. For example, people know that they need to upgrade their build system and want to find that section as fast as possible. Since this documentation is quite extensive, I think the format could benefit from a table of contents.
The proposed change in this commit only considers level 2 headings (equivalent to `##` resp. `<h2>`).